### PR TITLE
Clear out locals before rendering logout page

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -152,6 +152,8 @@ router.post('/signup', async (req, res) => {
 router.get('/logout', async (req, res) => {
     if (req.session.user) {
         req.session.destroy();
+        res.locals.user = false;
+        res.locals.superAdmin = false;
 
         res.render('auth/loggedout', { title: 'Logged out' });
     } else {


### PR DESCRIPTION
Otherwise you still see the "admin" button + logout button even though you are logged out (since it was performed in the middleware before logout took place)